### PR TITLE
Addition of NodeID and FindByID to VirtualFilesystem

### DIFF
--- a/ArchiveToolsLib/Archive/ArchiveReader.cs
+++ b/ArchiveToolsLib/Archive/ArchiveReader.cs
@@ -76,6 +76,7 @@ namespace WArchiveTools.Archives
                     {
                         node.Entries[i].SubDirIndex = entryDataOffset;
                         var newSubDir = allDirs[(int)entryDataOffset];
+                        newSubDir.NodeID = node.Entries[i].ID;
                         curDir.Children.Add(newSubDir);
                     }
                     else
@@ -87,6 +88,7 @@ namespace WArchiveTools.Archives
 
                         var vfFileContents = new VirtualFileContents(node.Entries[i].Data);
                         VirtualFilesystemFile vfFile = new VirtualFilesystemFile(fileName, extension, vfFileContents);
+                        vfFile.NodeID = node.Entries[i].ID;
                         curDir.Children.Add(vfFile);
                     }
 

--- a/ArchiveToolsLib/FileSystem/VirtualFilesystem.cs
+++ b/ArchiveToolsLib/FileSystem/VirtualFilesystem.cs
@@ -39,8 +39,22 @@ namespace WArchiveTools.FileSystem
             }
         }
 
+        /// <summary>
+        /// The ID of the node. If a <see cref="VirtualFilesystemDirectory"/> the ID is -1. If a <see cref="VirtualFilesystemFile"/> then it is a non-negative value.  
+        /// </summary>
+        public ushort NodeID
+        {
+            get { return m_nodeID; }
+            set
+            {
+                m_nodeID = value;
+                OnPropertyChanged("NodeID");
+            }
+        }
+
         private NodeType m_type;
         private string m_name;
+        private ushort m_nodeID;
 
         protected VirtualFilesystemNode(NodeType type, string name)
         {
@@ -105,6 +119,33 @@ namespace WArchiveTools.FileSystem
             }
 
             return validFiles;
+        }
+
+        /// <summary>
+        /// Returns the file whose node has the given NodeID, or null if there is no such file. Searches
+        /// all child directories recursively to look for the file.
+        /// </summary>
+        /// <param name="id">NodeID</param>
+        /// <returns>File with a matching NodeID</returns>
+        public VirtualFilesystemFile FindByID(ushort id)
+        {
+            VirtualFilesystemFile foundFile = null;
+
+            foreach (VirtualFilesystemNode child in Children)
+            {
+                if (child.Type == NodeType.File)
+                {
+                    if (child.NodeID == id)
+                        foundFile = child as VirtualFilesystemFile;
+                }
+                else if (child.Type == NodeType.Directory)
+                {
+                    VirtualFilesystemDirectory dir = (VirtualFilesystemDirectory)child;
+                    foundFile = dir.FindByID(id);
+                }
+            }
+
+            return foundFile;
         }
 
         /// <summary>


### PR DESCRIPTION
This commit adds a NodeID property to VirtualFilesystemNode and the function FindByID(ushort id) to VirtualFilesystemDirectory.  It also changes ArchiveReader.cs to set NodeID in files and directories.

These additions allow the user to search for files by their ID as given by the node system in the archive, which is critical in situations where the game relies on this ID to retrieve resources from it.